### PR TITLE
Stop trying to remove user from keychain twice.

### DIFF
--- a/CanvasKit/Networking/CKIClient.m
+++ b/CanvasKit/Networking/CKIClient.m
@@ -158,13 +158,6 @@ CKIUser * cki_loadCurrentUserFromKeychain(NSString *keychainID)
 
 #pragma mark - Properties
 
-- (void)setCurrentUser:(CKIUser *)currentUser
-{
-    _currentUser = currentUser;
-    [self saveToKeychain];
-}
-
-
 - (void)setAuthToken:(NSString *)authToken
 {
     _authToken = authToken;
@@ -287,6 +280,7 @@ CKIUser * cki_loadCurrentUserFromKeychain(NSString *keychainID)
     NSString *path = [CKIRootContext.path stringByAppendingPathComponent:@"users/self/profile"];
     [self fetchModelAtPath:path parameters:nil modelClass:[CKIUser class] context:nil success:^(CKIModel *user) {
         self.currentUser = (CKIUser *)user;
+        [self saveToKeychain];
     } failure:^(NSError *error) {
         NSLog(@"Error fetching user details: %@", error);
     }];


### PR DESCRIPTION
Fixes a small annoyance where the keychain would log a message saying it was trying to delete an object that didn't exist.
