### PR TITLE
Added support for Announcements which are basically Discussion Topics

### DIFF
--- a/CanvasKit/Networking/CKIClient+CKIDiscussionTopic.m
+++ b/CanvasKit/Networking/CKIClient+CKIDiscussionTopic.m
@@ -18,4 +18,11 @@
     return [self fetchResponseAtPath:path parameters:nil modelClass:[CKIDiscussionTopic class] context:course];
 }
 
+- (RACSignal *)fetchAnnouncementsForCourse:(CKICourse *)course
+{
+    NSString *path = [course.path stringByAppendingPathComponent:@"discussion_topics"];
+    
+    NSDictionary *params = @{@"only_announcements":@"true"};
+    return [self fetchResponseAtPath:path parameters:params modelClass:[CKIDiscussionTopic class] context:course];
+}
 @end


### PR DESCRIPTION
I just appended this Announcements fetch method to DiscussionTopics because Announcements are essentially DiscussionTopics.
