### PR TITLE
Add missing path variable for CKICalendarItems

### DIFF
--- a/CanvasKit/Models/CKICalendarEvent.h
+++ b/CanvasKit/Models/CKICalendarEvent.h
@@ -140,12 +140,12 @@
 /**
  If the event is a time slot, this is the participant limit
  */
-@property (nonatomic) NSInteger *participantsPerAppointment;
+//@property (nonatomic) NSInteger *participantsPerAppointment;
 
 /**
  If the event is a time slot and it has a participant limit, an integer indicating how many slots are available
  */
-@property (nonatomic) NSInteger *availableSlots;
+//@property (nonatomic) NSInteger *availableSlots;
 
 /**
  If the event is a user-level reservation, this will contain the user participant JSON (refer to the Users API)

--- a/CanvasKit/Models/CKICalendarEvent.m
+++ b/CanvasKit/Models/CKICalendarEvent.m
@@ -39,8 +39,8 @@
                                ,@"ownReservation": @"own_reservation"
                                ,@"reserveURL": @"reserve_url"
                                ,@"reserved": @"reserved"
-                               ,@"participantsPerAppointmnet": @"participants_per_appointment"
-                               ,@"availableSlots": @"available_slots"
+//                               ,@"participantsPerAppointmnet": @"participants_per_appointment"
+//                               ,@"availableSlots": @"available_slots"
                                ,@"user": @"user"
                                };
     NSDictionary *superPaths = [super JSONKeyPathsByPropertyKey];


### PR DESCRIPTION
I am not sure why but for some reason the context path seems to be missing so I used a different pattern that we use in the networking category (CKIClient+CKICalendarItems) to get the path.
