### PR TITLE
Adding support for Groups

### DIFF
--- a/CanvasKit/Models/CKIAssignment.h
+++ b/CanvasKit/Models/CKIAssignment.h
@@ -46,7 +46,7 @@ typedef enum {
 /**
  The date after which the assignment is locked. nil if this assignment is
  never locked.
- 
+
  @warning If this assignment has assignment overrides, use the date from
  the override instead.
  */
@@ -200,15 +200,5 @@ typedef enum {
  @note This is NOT valid unless you have automatic_peer_reviews set to true.
  */
 @property (nonatomic, strong) NSDate *peerReviewsAssignAt;
-    
-
-#pragma mark - CKIModel
-/** @name CKIModel Overrides. */
-
-/**
- The context for an assignment is a CKICourse object. This override
- is a convenience and merely adds the type of the context back in.
- */
-@property (nonatomic, readonly) CKICourse *context;
 
 @end

--- a/CanvasKit/Models/CKITab.h
+++ b/CanvasKit/Models/CKITab.h
@@ -18,5 +18,4 @@
 
 @property (nonatomic, strong) NSString *type;
 
-@property (nonatomic) CKICourse *context;
 @end

--- a/CanvasKit/Networking/CKIClient+CKIAssignment.h
+++ b/CanvasKit/Networking/CKIClient+CKIAssignment.h
@@ -13,6 +13,7 @@
 
 @interface CKIClient (CKIAssignment)
 
+- (RACSignal *)fetchAssignmentsForContext:(id<CKIContext>)context;
 - (RACSignal *)fetchAssignmentsForCourse:(CKICourse *)course;
 
 @end

--- a/CanvasKit/Networking/CKIClient+CKIAssignment.m
+++ b/CanvasKit/Networking/CKIClient+CKIAssignment.m
@@ -14,6 +14,12 @@
 
 @implementation CKIClient (CKIAssignment)
 
+- (RACSignal *)fetchAssignmentsForContext:(id<CKIContext>)context
+{
+    NSString *path = [[context path] stringByAppendingPathComponent:@"assignments"];
+    return [self fetchResponseAtPath:path parameters:@{@"include": @[@"submission"]} modelClass:[CKIAssignment class] context:context];
+}
+
 - (RACSignal *)fetchAssignmentsForCourse:(CKICourse *)course
 {
     NSString *path = [[course path] stringByAppendingPathComponent:@"assignments"];

--- a/CanvasKit/Networking/CKIClient+CKIAssignmentGroup.h
+++ b/CanvasKit/Networking/CKIClient+CKIAssignmentGroup.h
@@ -14,5 +14,6 @@
 @interface CKIClient (CKIAssignmentGroup)
 
 - (RACSignal *)fetchAssignmentGroupsForCourse:(CKICourse *)course;
+- (RACSignal *)fetchAssignmentGroupsForContext:(id <CKIContext>)context;
 
 @end

--- a/CanvasKit/Networking/CKIClient+CKIAssignmentGroup.m
+++ b/CanvasKit/Networking/CKIClient+CKIAssignmentGroup.m
@@ -28,4 +28,17 @@
     }];
 }
 
+- (RACSignal *)fetchAssignmentGroupsForContext:(id <CKIContext>)context
+{
+    NSString *path = [[context path] stringByAppendingPathComponent:@"assignment_groups"];
+    return [[self fetchResponseAtPath:path parameters:nil modelClass:[CKIAssignmentGroup class] context:context] map:^id(NSArray *assignmentGroups) {
+        for (CKIAssignmentGroup *group in assignmentGroups) {
+            for (CKIAssignment *assignment in group.assignments) {
+                assignment.context = context;
+            }
+        }
+        return assignmentGroups;
+    }];
+}
+
 @end

--- a/CanvasKit/Networking/CKIClient+CKICalendarEvent.h
+++ b/CanvasKit/Networking/CKIClient+CKICalendarEvent.h
@@ -36,4 +36,6 @@
  */
 - (RACSignal *)fetchCalendarEvents;
 
+- (RACSignal *)fetchCalendarEventsForContext:(id<CKIContext>)context;
+
 @end

--- a/CanvasKit/Networking/CKIClient+CKICalendarEvent.m
+++ b/CanvasKit/Networking/CKIClient+CKICalendarEvent.m
@@ -11,6 +11,7 @@
 #import "CKIClient+CKICalendarEvent.h"
 #import "CKICalendarEvent.h"
 #import "CKICourse.h"
+#import "CKIGroup.h"
 
 @implementation CKIClient (CKICalendarEvent)
 
@@ -19,6 +20,26 @@
     NSString *path = [CKIRootContext.path stringByAppendingPathComponent:@"calendar_events"];
     
     NSString *contextCode = [NSString stringWithFormat:@"course_%@", course.id];
+    NSDictionary *params = @{@"type": @"event",
+                             @"context_codes": @[contextCode],
+                             @"start_date": @"1900-01-01",
+                             @"end_date": @"2099-12-31"};
+    return [self fetchResponseAtPath:path parameters:params modelClass:[CKICalendarEvent class] context:nil];
+}
+
+- (RACSignal *)fetchCalendarEventsForContext:(id<CKIContext>)context
+{
+    NSString *path = [CKIRootContext.path stringByAppendingPathComponent:@"calendar_events"];
+    
+    NSString *contextCode = @"";
+    if ([[context path] rangeOfString:@"courses"].location != NSNotFound){
+        contextCode = [NSString stringWithFormat:@"course_%@", context];
+    } else if ([[context path] rangeOfString:@"groups"].location != NSNotFound){
+        contextCode = [NSString stringWithFormat:@"groups_%@", context];
+    } else if ([[context path] rangeOfString:@"users"].location != NSNotFound) {
+        contextCode = [NSString stringWithFormat:@"users_%@", context];
+    }
+    
     NSDictionary *params = @{@"type": @"event",
                              @"context_codes": @[contextCode],
                              @"start_date": @"1900-01-01",

--- a/CanvasKit/Networking/CKIClient+CKIDiscussionTopic.h
+++ b/CanvasKit/Networking/CKIClient+CKIDiscussionTopic.h
@@ -12,5 +12,10 @@
 
 @interface CKIClient (CKIDiscussionTopic)
 - (RACSignal *)fetchDiscussionTopicsForCourse:(CKICourse *)course;
+- (RACSignal *)fetchDiscussionTopicForCourse:(CKICourse *)course topicID:(NSString *)topicID;
 - (RACSignal *)fetchAnnouncementsForCourse:(CKICourse *)course;
+
+- (RACSignal *)fetchDiscussionTopicsForContext:(id<CKIContext>)context;
+- (RACSignal *)fetchDiscussionTopicForContext:(id<CKIContext>)context topicID:(NSString *)topicID;
+- (RACSignal *)fetchAnnouncementsForContext:(id<CKIContext>)context;
 @end

--- a/CanvasKit/Networking/CKIClient+CKIDiscussionTopic.m
+++ b/CanvasKit/Networking/CKIClient+CKIDiscussionTopic.m
@@ -33,4 +33,26 @@
     return [self fetchResponseAtPath:path parameters:params modelClass:[CKIDiscussionTopic class] context:course];
 }
 
+
+- (RACSignal *)fetchDiscussionTopicsForContext:(id<CKIContext>)context
+{
+    NSString *path = [context.path stringByAppendingPathComponent:@"discussion_topics"];
+    return [self fetchResponseAtPath:path parameters:nil modelClass:[CKIDiscussionTopic class] context:context];
+}
+
+- (RACSignal *)fetchDiscussionTopicForContext:(id<CKIContext>)context topicID:(NSString *)topicID
+{
+    NSString *path = [context.path stringByAppendingPathComponent:@"discussion_topics"];
+    path = [path stringByAppendingPathComponent:[NSString stringWithFormat: @"%@", topicID]];
+    return [self fetchResponseAtPath:path parameters:nil modelClass:[CKIDiscussionTopic class] context:context];
+}
+
+- (RACSignal *)fetchAnnouncementsForContext:(id<CKIContext>)context
+{
+    NSString *path = [context.path stringByAppendingPathComponent:@"discussion_topics"];
+    
+    NSDictionary *params = @{@"only_announcements":@"true"};
+    return [self fetchResponseAtPath:path parameters:params modelClass:[CKIDiscussionTopic class] context:context];
+}
+
 @end

--- a/CanvasKit/Networking/CKIClient+CKIFolder.h
+++ b/CanvasKit/Networking/CKIClient+CKIFolder.h
@@ -44,4 +44,9 @@
  */
 - (RACSignal *)fetchFilesForFolder:(CKIFolder *)folder;
 
+
+- (RACSignal *)fetchFolder:(NSString *)folderID withContext:(id<CKIContext>)context;
+
+- (RACSignal *)fetchRootFolderForContext:(id <CKIContext>)context;
+
 @end

--- a/CanvasKit/Networking/CKIClient+CKIFolder.m
+++ b/CanvasKit/Networking/CKIClient+CKIFolder.m
@@ -44,4 +44,19 @@
     return [self fetchResponseAtPath:path parameters:nil modelClass:[CKIFile class] context:folder.context];
 }
 
+
+- (RACSignal *)fetchFolder:(NSString *)folderID withContext:(id<CKIContext>)context
+{
+    NSString *path = [context.path stringByAppendingPathComponent:@"folders"];
+    path = [path stringByAppendingPathComponent:folderID];
+    return [self fetchResponseAtPath:path parameters:nil modelClass:[CKIFolder class] context:context];
+}
+
+- (RACSignal *)fetchRootFolderForContext:(id <CKIContext>)context
+{
+    NSString *path = [context.path stringByAppendingPathComponent:@"folders/root"];
+    return [self fetchResponseAtPath:path parameters:nil modelClass:[CKIFolder class] context:context];
+}
+
+
 @end

--- a/CanvasKit/Networking/CKIClient+CKIGroup.h
+++ b/CanvasKit/Networking/CKIClient+CKIGroup.h
@@ -22,4 +22,7 @@
 
 - (RACSignal *)fetchGroupsForCourse:(CKICourse *)course;
 
+- (RACSignal *)fetchGroup:(NSString *)groupID withContext:(id<CKIContext>)context;
+
+- (RACSignal *)fetchGroupsForContext:(id <CKIContext>)context;
 @end

--- a/CanvasKit/Networking/CKIClient+CKIGroup.m
+++ b/CanvasKit/Networking/CKIClient+CKIGroup.m
@@ -44,4 +44,19 @@
     return [self fetchResponseAtPath:path parameters:nil modelClass:[CKIGroup class] context:course];
 }
 
+- (RACSignal *)fetchGroup:(NSString *)groupID withContext:(id<CKIContext>)context
+{
+    NSString *path = [context.path stringByAppendingPathComponent:@"groups"];
+    path = [path stringByAppendingPathComponent:groupID];
+    return [self fetchResponseAtPath:path parameters:nil modelClass:[CKIGroup class] context:context];
+}
+
+- (RACSignal *)fetchGroupsForContext:(id <CKIContext>)context
+{
+    NSString *path = [context.path stringByAppendingPathComponent:@"courses"];
+    path = [path stringByAppendingPathComponent:[context description]];
+    path = [path stringByAppendingPathComponent:@"groups"];
+    return [self fetchResponseAtPath:path parameters:nil modelClass:[CKIGroup class] context:context];
+}
+
 @end

--- a/CanvasKit/Networking/CKIClient+CKIPage.h
+++ b/CanvasKit/Networking/CKIClient+CKIPage.h
@@ -18,4 +18,8 @@
 
 - (RACSignal *)fetchPage:(NSString *)id forCourse:(CKICourse *)course;
 
+- (RACSignal *)fetchPagesForContext:(id<CKIContext>)context;
+
+- (RACSignal *)fetchPage:(NSString *)pageId forContext:(id<CKIContext>)context;
+
 @end

--- a/CanvasKit/Networking/CKIClient+CKIPage.m
+++ b/CanvasKit/Networking/CKIClient+CKIPage.m
@@ -25,4 +25,17 @@
     return [self fetchResponseAtPath:path parameters:nil modelClass:[CKIPage class] context:course];
 }
 
+- (RACSignal *)fetchPagesForContext:(id<CKIContext>)context
+{
+    NSString *path = [context.path stringByAppendingPathComponent:@"pages"];
+    return [self fetchResponseAtPath:path parameters:nil modelClass:[CKIPage class] context:context];
+}
+
+- (RACSignal *)fetchPage:(NSString *)pageId forContext:(id<CKIContext>)context
+{
+    NSString * path = [context.path stringByAppendingPathComponent:@"pages"];
+    path = [path stringByAppendingPathComponent:pageId];
+    return [self fetchResponseAtPath:path parameters:nil modelClass:[CKIPage class] context:context];
+}
+
 @end

--- a/CanvasKit/Networking/CKIClient+CKITab.h
+++ b/CanvasKit/Networking/CKIClient+CKITab.h
@@ -16,4 +16,6 @@
 
 - (RACSignal *)fetchTabsForCourse:(CKICourse *)course;
 
+- (RACSignal *)fetchTabsForContext:(id<CKIContext>)context;
+
 @end

--- a/CanvasKit/Networking/CKIClient+CKITab.m
+++ b/CanvasKit/Networking/CKIClient+CKITab.m
@@ -21,10 +21,10 @@
     return [self fetchResponseAtPath:path parameters:nil modelClass:[CKITab class] context:course];
 }
 
-- (RACSignal *)fetchTabsForGroup:(CKIGroup *)group
+- (RACSignal *)fetchTabsForContext:(id<CKIContext>)context
 {
-    NSString *path = [[group path] stringByAppendingPathComponent:@"tabs"];
-    return [self fetchResponseAtPath:path parameters:nil modelClass:[CKITab class] context:group];
+    NSString *path = [[context path] stringByAppendingPathComponent:@"tabs"];
+    return [self fetchResponseAtPath:path parameters:nil modelClass:[CKITab class] context:context];
 }
 
 @end

--- a/CanvasKit/Networking/CKIClient+CKIUser.h
+++ b/CanvasKit/Networking/CKIClient+CKIUser.h
@@ -38,4 +38,8 @@
  */
 - (RACSignal *)fetchUsersMatchingSearchTerm:(NSString *)searchTerm course:(CKICourse *)course;
 
+
+- (RACSignal *)fetchUsersForContext:(id<CKIContext>)context;
+
+- (RACSignal *)fetchUsersWithParameters:(NSDictionary *)parameters context:(id<CKIContext>)context;
 @end

--- a/CanvasKit/Networking/CKIClient+CKIUser.m
+++ b/CanvasKit/Networking/CKIClient+CKIUser.m
@@ -36,4 +36,19 @@
     return [self fetchResponseAtPath:path parameters:parameters modelClass:[CKIUser class] context:course];
 }
 
+- (RACSignal *)fetchUsersForContext:(id<CKIContext>)context
+{
+    return [self fetchUsersWithParameters:nil context:context];
+}
+
+- (RACSignal *)fetchUsersWithParameters:(NSDictionary *)parameters context:(id<CKIContext>)context
+{
+    NSString *path = [context.path stringByAppendingPathComponent:@"users"];
+    
+    NSMutableDictionary *updatedParameters = [parameters mutableCopy];
+    [updatedParameters setObject:@[@"avatar_url"] forKey:@"include"];
+    
+    return [self fetchResponseAtPath:path parameters:updatedParameters modelClass:[CKIUser class] context:context];
+}
+
 @end


### PR DESCRIPTION
Add support for fetching with id<CKIContext> for Groups
Removed "context" properties from model related to Groups

For methods related to Groups I added fetching ForContext: in place of ForCourse:. We want to phase out the old ForCourse: methods once we feel confident about the new ForContext: methods. 
