### PR TITLE
Only bail on 401s after attempting to fetch current user

### DIFF
--- a/CanvasKit/Networking/CKIClient.h
+++ b/CanvasKit/Networking/CKIClient.h
@@ -11,6 +11,8 @@
 @class CKIUser;
 @class RACSignal;
 
+extern NSString *const CKIClientAccessTokenExpiredNotification;
+
 @protocol CKIContext;
 
 /**


### PR DESCRIPTION
if another 401 occurs when fetching the current user, then we know we have a
problem and should bail.
