### PR TITLE
Update Mantle dependency to latest 1.5 & fix related Model issues

### DIFF
--- a/CanvasKit.podspec
+++ b/CanvasKit.podspec
@@ -1,11 +1,11 @@
 Pod::Spec.new do |s|
   s.name     = 'CanvasKit'
-  s.version  = '0.47'
+  s.version  = '0.51'
   s.license  = 'MIT'
   s.summary  = 'A Canvas API integration framework better than bamboo'
   s.homepage = 'https://github.com/instructure/CanvasKit'
   s.authors  = { 'Rick Roberts' => 'elgreco84@gmail.com', 'Jason Larsen' => 'jason.larsen@gmail.com' }
-  s.source   = { :git => 'https://github.com/instructure/CanvasKit.git', :tag => 'v0.47' }
+  s.source   = { :git => 'https://github.com/instructure/CanvasKit.git', :tag => 'v0.51' }
   s.requires_arc = true
 
   s.ios.deployment_target = '7.0'
@@ -15,7 +15,7 @@ Pod::Spec.new do |s|
   s.osx.source_files = 'CanvasKit/Helpers/*.{h,m}', 'CanvasKit/Models/*.{h,m}', 'CanvasKit/Networking/*.{h,m}', 'CanvasKit/CanvasKit.h', 'CanvasKit/Constants.h'
 
   s.dependency 'AFNetworking', '~> 2.0'
-  s.dependency 'Mantle', '1.4.1'
+  s.dependency 'Mantle', '~> 1.0'
   s.dependency 'ISO8601DateFormatter'
   s.dependency 'ReactiveCocoa'
 end

--- a/CanvasKit/UIKit+CanvasKit/CKILoginViewController.m
+++ b/CanvasKit/UIKit+CanvasKit/CKILoginViewController.m
@@ -30,7 +30,7 @@
     // remove cookies to dispose of previous login session
     NSHTTPCookieStorage *storage = [NSHTTPCookieStorage sharedHTTPCookieStorage];
     NSArray *oldCookies = [storage.cookies.rac_sequence filter:^BOOL(NSHTTPCookie *cookie) {
-        return [cookie.domain containsString:domain];
+        return [cookie.domain rangeOfString:domain].location != NSNotFound;
     }].array;
     for (NSHTTPCookie *oldCookie in oldCookies) {
         [storage deleteCookie:oldCookie];

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -26,9 +26,9 @@ PODS:
   - Kiwi/XCTest (2.2.4):
     - Kiwi/ARC
     - Kiwi/NonARC
-  - Mantle (1.4.1):
+  - Mantle (1.5):
     - Mantle/extobjc
-  - Mantle/extobjc (1.4.1)
+  - Mantle/extobjc (1.5)
   - ReactiveCocoa (2.3.1):
     - ReactiveCocoa/UI
   - ReactiveCocoa/Core (2.3.1):
@@ -41,14 +41,14 @@ DEPENDENCIES:
   - AFNetworking (~> 2.0)
   - ISO8601DateFormatter
   - Kiwi/XCTest
-  - Mantle (= 1.4.1)
+  - Mantle (~> 1.0)
   - ReactiveCocoa
 
 SPEC CHECKSUMS:
   AFNetworking: 6d7b76aa5d04c8c37daad3eef4b7e3f2a7620da3
   ISO8601DateFormatter: 59731cd880cf87e71b4fa95f0d6b713dcbc4cbce
   Kiwi: c73667f2b84cbf36f1a3830267c5a4ae8dcbd8ba
-  Mantle: 1ca9c0fa84d3d3fc98524e7229f30489b6dd44e5
+  Mantle: c67a7e45e14196ed42b2a7cbb98ff6a9920e6b92
   ReactiveCocoa: dca75777b9d18990c8714a3a6f2149f29b4d1462
 
 COCOAPODS: 0.33.1


### PR DESCRIPTION
The update to the pod spec version doesn't really matter, it just bothered me that it was out of date.
The range check on string is a fix for replacing iOS 8 code to iOS 7 code
The mantle update changes don't appear to affect other apps negatively
