### PR TITLE
Fix for video thumbnail request

### DIFF
--- a/CanvasKit/Networking/CKIClient+CKISubmissionComment.m
+++ b/CanvasKit/Networking/CKIClient+CKISubmissionComment.m
@@ -64,7 +64,7 @@
 - (void)getThumbnailForMediaComment:(CKIMediaComment *)mediaComment ofSize:(CGSize)size success:(void(^)(UIImage *image))success failure:(void(^)(NSError *error))failure {
     
     [self configureMediaServerWithSuccess:^{
-        NSString *urlString = [NSString stringWithFormat:@"p/%@/thumbnail/entry_id/%@/width/%@/height/%@/bgcolor/000000/type/1/vid_sec/5", @(self.mediaServer.partnerId), mediaComment.mediaID, @(size.width), @(size.height)];
+        NSString *urlString = [NSString stringWithFormat:@"p/%@/thumbnail/entry_id/%@/width/%@/height/%@/bgcolor/000000/type/1/vid_sec/5", self.mediaServer.partnerId, mediaComment.mediaID, @(size.width), @(size.height)];
         
         AFHTTPRequestOperationManager *manager = [[AFHTTPRequestOperationManager alloc] initWithBaseURL:self.mediaServer.resourceDomain];
         manager.responseSerializer = [AFImageResponseSerializer serializer];

--- a/CanvasKit/Networking/CKIMediaServer.h
+++ b/CanvasKit/Networking/CKIMediaServer.h
@@ -12,7 +12,7 @@
 @property (nonatomic, assign, getter = isEnabled) BOOL enabled;
 @property (nonatomic, strong) NSURL *domain;
 @property (nonatomic, strong) NSURL *resourceDomain;
-@property (nonatomic, assign) uint64_t partnerId;
+@property (nonatomic, strong) NSString *partnerId;
 
 - (id)initWithInfo:(NSDictionary *)info;
 


### PR DESCRIPTION
mediaServers partnerId is not a uin64_t it is parsed as an NSString
