### PR TITLE
Pegged Mantle to v1.5.5 for the time being.

### DIFF
--- a/CanvasKit.podspec
+++ b/CanvasKit.podspec
@@ -14,7 +14,7 @@ Pod::Spec.new do |s|
   s.resources = 'CanvasKit/**/*.{js}','CanvasKit/**/*.{css}'
 
   s.dependency 'AFNetworking', '~> 2.5.1'
-  s.dependency 'Mantle', '~> 1.0'
+  s.dependency 'Mantle', '1.5.5'
   s.dependency 'ISO8601DateFormatter', '~> 0.7'
   s.dependency 'ReactiveCocoa', '~> 2.4.2'
 end

--- a/Podfile
+++ b/Podfile
@@ -5,7 +5,7 @@ podspec :path => 'CanvasKit.podspec'
 
 target "CanvasKitTests" do
   pod 'AFNetworking', '~> 2.5.1'
-  pod 'Mantle', '~> 1.0'
+  pod 'Mantle', '1.5.5'
 #  pod 'ISO8601DateFormatter'
 #  pod 'ReactiveCocoa'
 end


### PR DESCRIPTION
Mantle v1.5.6 changed EXTScope to a private class which broke like 52 classes.  We need to get a build out so we'll peg to 1.5.5 for the time being.