### PR TITLE
Fix transforming ids that are stored as strings

### DIFF
--- a/CanvasKit/Models/CKIModel.m
+++ b/CanvasKit/Models/CKIModel.m
@@ -47,8 +47,14 @@
 
 + (NSValueTransformer *)idJSONTransformer
 {
-    return [NSValueTransformer valueTransformerForName:CKINumberStringTransformerName];
-}
+    return [MTLValueTransformer reversibleTransformerWithForwardBlock:^ id (id someNumber) {
+        if ([someNumber isKindOfClass:[NSString class]]) {
+            return someNumber;
+        }
+        return [someNumber stringValue];
+    } reverseBlock:^ id (NSString *stringifiedNumber) {
+        return [NSNumber numberWithLongLong:[stringifiedNumber longLongValue]];
+    }];}
 
 // Overridden to prevent NSInvalidArgumentException in cases where the API
 // is returning 'null' for integral types. Mantle does not check to see if


### PR DESCRIPTION
This was causing a crash on boot, not sure why. The only information
I can provide is that it only happened when I ran Canvas on an iPod
touch that had been sitting around inactive for who-knows-how-long.